### PR TITLE
DOCSP-9667: add banner with link to new docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,45 @@ To build you need the following tools installed
 * Hugo static web generator `v0.30.2`
     * You can download the right version [here](https://github.com/gohugoio/hugo/releases/tag/v0.30.2)
 * jsdoc v3
-* node (v6.x or v8.x) and npm (>= 3.x)
+* node (v6.x or v8.x) and npm (>= 3.x). Note: worked for me with 8.17.0, but not 8.0.0.
 * python sphinx
 
-## How to build the documentations
+
+## How to preview the documentation locally
+
+* Install dependencies; ensure you are using the correct npm version in your current shell
+* Run `make setup generate_main_docs` to pull each version branch of the docs
+  and run `hugo` on them to generate the publishable files.
+* At this point, you should be able to run hugo server to preview the
+  landing page
+* To view one of the reference docs branches, copy the <root>/public/<version>
+  directory to <root>/site/content. Note: for referenced styles, you'll need 
+  to manually update all the paths to remove `/node-mongodb-native` from the 
+  path.
+* If you need to make local changes to preview the reference docs before
+  publishing, build them with hugo and copy them over. For example:
+  ```
+  cd <root>/checkout/<version>
+  hugo -s docs/reference --destination ../../public -b /<version> -t mongodb --verbose --debug
+  cp -r public/ <root>/site/content/<version>
+  ```
+* Start hugo server, specifying `--contentDir=content`, and at this point
+  you should be able to follow the links. Your command might look like
+  this:
+  ```
+  hugo server --baseUrl=http://localhost/ --buildDrafts --watch --contentDir=content
+  ```
+* If you are working on updating a branch, make sure the PR is against
+  the appropriate branch of the `node-mongodb-native` repo.
+
+## How to publish the documentation
 
 * Install all dependencies
 * run `make`
 
 ## How to add a new version
 
-This will assume that you are adding a new minor version `3.4`
+This assumes that you are adding a new minor version `3.4`
 
 ### Update `Makefile`
 

--- a/site/config.toml
+++ b/site/config.toml
@@ -4,3 +4,6 @@ title = "MongoDB Node.js Driver"
 canonifyurls = false
 
 githubRepo = "node-mongodb-native"
+
+[params]
+    referenceDocsUrl = "https://docs.mongodb.com/drivers/node"

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -16,6 +16,8 @@
 
   {{ partial "hero.html" . }}
 
+  {{ partial "banners/new_version.html" . }}
+
   <!-- Main content -->
   <div class="container" id="mainContent">
     <div class="row">

--- a/site/layouts/partials/banners/new_version.html
+++ b/site/layouts/partials/banners/new_version.html
@@ -1,0 +1,5 @@
+<div class="alert alert-info" role="alert">
+  Note: This documentation is for versions of the Node.js driver up to 3.6 only.
+  For documentation of newer versions of the driver,
+  <a href="{{.Site.Params.ReferenceDocsUrl}}">click here</a>.
+</div>

--- a/site/layouts/partials/hero.html
+++ b/site/layouts/partials/hero.html
@@ -10,7 +10,7 @@
       <p>
         {{ range where $.Site.Data.releases.versions "version" $.Site.Data.releases.current  }}{{ $.Scratch.Set "qs.currentReleasedVersion" . }}{{end }}
         {{$currentReleasedVersion := $.Scratch.Get "qs.currentReleasedVersion"}}
-      <a href="{{$currentReleasedVersion.docs}}" class="btn btn-success btn-dark btn-mongo">Latest documentation</a>
+        <a href="{{$.Site.Params.referenceDocsUrl}}" class="btn btn-success btn-dark btn-mongo">Latest documentation</a>
       </p>
 
     </div>


### PR DESCRIPTION
## Note: Do not publish until 4.4 GA

[DOCSP-9667](https://jira.mongodb.org/browse/DOCSP-9667)

### Changes:
* Added banner with link to the new reference documentation site
* Updated README for local preview instructions

![Screen Shot 2020-07-21 at 12 29 48 AM](https://user-images.githubusercontent.com/52428683/88072593-39220680-cb43-11ea-84e1-34305af219fb.png)

